### PR TITLE
Fixed typo in implementation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
 Resource configuration for a private repo:
 
 ``` yaml
-resource_type:
+resource_types:
 - name: git-multibranch
   type: docker-image
   source:


### PR DESCRIPTION
`resource_type:`

Heeds to read

`resource_types:`

Hopefully will save others flailing around trying to figure out what's up like I did!